### PR TITLE
youngjun-0524

### DIFF
--- a/youngjun/1_연속펄스부분수열의합.py
+++ b/youngjun/1_연속펄스부분수열의합.py
@@ -1,0 +1,25 @@
+def solution(sequence):
+    #펄스 수열이 1로 시작할 때
+    mul_1 = 1
+    sum_1 = 0
+    answer_1 = 0
+    
+    #펄스 수열이 -1로 시작할 때
+    mul_2 = -1
+    sum_2 = 0
+    answer_2 = 0
+    
+    for i in sequence:
+        sum_1 += i * mul_1
+        answer_1 = max(answer_1, sum_1)
+        if sum_1 <= 0: #누적합이 0 이하일 때 0으로 초기화
+            sum_1 = 0
+        mul_1 *= -1
+        
+        sum_2 += i * mul_2
+        answer_2 = max(answer_2, sum_2)
+        if sum_2 <= 0: #누적합이 0 이하일 때 0으로 초기화
+            sum_2 = 0
+        mul_2 *= -1
+        
+    return max(answer_1,answer_2)


### PR DESCRIPTION
### 📌 푼 문제들

- 문제 1 연속 펄스 부분 수열의 합

---

### 📝 간단한 풀이 과정

#### 연속 펄스 부분 수열의 합

- 펄스 수열 값을 곱해서 누적합을 구하며 큰 값은 저장
- 누적합이 0보다 작은 경우에는 그 때 까지의 누적합은 버려야 가장 큰 값을 찾을 수 있기 때문에 누적합을 0으로 초기화
- 두 가지 펄스 수열 경우를 구한 후 더 큰값 반환
---
